### PR TITLE
Add input to set visibility of posted status

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ jobs:
         with:
           # This is the RSS feed you want to publish
           rss-feed: https://www.githubstatus.com/history.rss
+          # Visibility of the posted status (public | unlisted | private | direct)
+          status-visibility: public
           # This is your instance address
           api-endpoint: https://mastodon.social
           # This is the secret you created earlier

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   rss-feed:
     description: 'RSS feed URL'
     required: true
+  status-visibility:
+    description: 'Visibility of the posted status (public | unlisted | private | direct)'
+    required: false
+    default: 'public'
   cache-file:
     description: 'Cache file'
     required: true


### PR DESCRIPTION
On some instances it is frowned upon when bot accounts post public status which might spam the local timeline.

This pull request adds the input `status-visibility` which controls the visibility of the posted status and can be set to one of the following values:

- `public` = Visible to everyone, shown in public timelines.
- `unlisted` = Visible to public, but not included in public timelines.
- `private` = Visible to followers only, and to any mentioned users.
- `direct` = Visible only to mentioned users.