### PR TITLE
Migrate from `feed-reader` to `@extractus/feed-extractor`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@selfagency/mastofeedbot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@selfagency/mastofeedbot",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
+        "@extractus/feed-extractor": "^6.1.7",
         "@sohailalam2/abu": "^0.4.0",
-        "feed-reader": "^6.1.3",
         "masto": "^4.6.2",
         "mkdirp": "^1.0.4"
       },
@@ -102,6 +102,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@extractus/feed-extractor": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/@extractus/feed-extractor/-/feed-extractor-6.1.7.tgz",
+      "integrity": "sha512-wbgr+gTY+xvh88/mgKnTUdevMsqFVokLd2JOxenbiTiMF0ADzsf7YAzyXQyWHFLQ3Cj+DFrpNrQU5Udy/3ZEFw==",
+      "dependencies": {
+        "bellajs": "^11.1.1",
+        "cross-fetch": "^3.1.5",
+        "fast-xml-parser": "^4.0.12",
+        "html-entities": "^2.3.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1852,9 +1866,9 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.12.tgz",
+      "integrity": "sha512-/Nmo3823Rfx7UTJosQNz6hBVbszfv1Unb7A4iNJZhvCGCgtIHv/uODmrYIH8vc05+XKZ4hNIOv6SlBejvJgATw==",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -1873,20 +1887,6 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/feed-reader": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/feed-reader/-/feed-reader-6.1.3.tgz",
-      "integrity": "sha512-C6l3SYGimz77peqDycYuQTfp6heuDJFpgStY6L5Yxagjg7EWz8uz0esqTUTo3WKL8WgXIOlT4eH7/Qa78N0Egw==",
-      "dependencies": {
-        "bellajs": "^11.1.1",
-        "cross-fetch": "^3.1.5",
-        "fast-xml-parser": "^4.0.11",
-        "html-entities": "^2.3.3"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/file-entry-cache": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@sohailalam2/abu": "^0.4.0",
-    "feed-reader": "^6.1.3",
+    "@extractus/feed-extractor": "^6.1.7",
     "masto": "^4.6.2",
     "mkdirp": "^1.0.4"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile } from 'fs/promises';
 import { SHA256Hash } from '@sohailalam2/abu';
 import * as core from '@actions/core';
 import mkdirp from 'mkdirp';
-import { type FeedEntry, read } from 'feed-reader';
+import { type FeedEntry, read } from '@extractus/feed-extractor';
 
 async function writeCache(cacheFile: string, cacheLimit: number, cache: string[]): Promise<void> {
   try {


### PR DESCRIPTION
The `feed-reader` project changed the package name from `feed-reader` to `@extractus/feed-extractor`.

https://github.com/extractus/feed-extractor/releases/tag/v6.1.4